### PR TITLE
Add photo by Avery Magnotti

### DIFF
--- a/debian/copyright
+++ b/debian/copyright
@@ -10,6 +10,7 @@ Ryan Schroeder <https://unsplash.com/photos/Gg7uKdHFb_c>
 Photo by SpaceX <https://unsplash.com/photos/VBNb52J8Trk>
 Samuel Zeller <https://unsplash.imgix.net/photo-1418225085675-d9ee79523efb?q=75&fm=jpg&s=aa95d693e0f73036db1efad137c4a765>
 Carmine De Fazio <https://unsplash.com/photos/3ytjETpQMNY>
+Avery Magnotti <https://unsplash.com/photos/GFDYE4HlVYU>
 
 Licensed under Attribution 2.0 Generic <https://creativecommons.org/licenses/by/2.0/>:
 


### PR DESCRIPTION
- [x] I've read and followed the [general guidelines](https://github.com/elementary/wallpapers#general-wallpaper-guidelines)
  - [x] Looks good in Pantheon on elementary OS
  - [x] Not too distracting if a non-maximized window is open
  - [x] No text or logos
  - [x] No people
  - [x] At least 3200×1800 px
- [x] I've upated `debian/copyright` with:
  - [x] The name of the wallpaper and/or its original author
  - [x] A link to where it can be downloaded
  - [x] Included under the respective license section (or created a new one if appropriate)
- [x] I've added the artist metadata using `exiftool`

## Why it should be included:

This image fits elementary OS's theme of peaceful and minimal nature landscapes, as well as areas with vibrant colors only found in remote places of the world. It's unobtrusive and allows the desktop to breathe; an intentional visual effect of the clear sky and seamless mirrored lake pictured below.

Thanks!

## Screenshot(s) of it in Pantheon on elementary OS:

### Clean desktop

![screenshot from 2017-11-07 09 19 06](https://user-images.githubusercontent.com/9056756/32498178-ea01be02-c39c-11e7-9842-d65772d48a38.png)

### With non-maximized window open

![screenshot from 2017-11-07 09 19 20](https://user-images.githubusercontent.com/9056756/32498180-ed937ccc-c39c-11e7-838a-ee19bb16245f.png)


