### PR TITLE
'Luca Bravo' wallpaper added

### DIFF
--- a/debian/copyright
+++ b/debian/copyright
@@ -12,3 +12,4 @@ Photo by SpaceX <https://unsplash.com/photos/VBNb52J8Trk>
 Samuel Zeller <https://unsplash.imgix.net/photo-1418225085675-d9ee79523efb?q=75&fm=jpg&s=aa95d693e0f73036db1efad137c4a765>
 Carmine De Fazio <https://unsplash.com/photos/3ytjETpQMNY>
 Sunset by the Pier <https://unsplash.com/photos/ces8_Bo7bhQ>
+Luca Bravo <https://unsplash.com/photos/4yta6mU66dE>


### PR DESCRIPTION
- [x] I've read and followed the [general guidelines](https://github.com/elementary/wallpapers#general-wallpaper-guidelines)
  - [x] Looks good in Pantheon on elementary OS
  - [x] Not too distracting if a non-maximized window is open
  - [x] No text or logos
  - [x] No people
  - [x] At least 3200×1800 px
- [x] I've updated `debian/copyright` with:
  - [x] The name of the wallpaper and/or its original author
  - [x] A link to where it can be downloaded
  - [x] Included under the respective license section (or created a new one if appropriate)
- [x] I've added the artist metadata using `exiftool`
## Why it should be included:

I think it looks like a good candidate as a shipped wallpaper for a new release, it doesn't have pesky specks mudding the photo as to make Wingpanel force itself to be with a bg, and it has a lovely contrast between the wingpanel part and the dock part of the desktop.

## Screenshot(s) of it in Pantheon on elementary OS:

![The wallpaper in action](https://my.mixtape.moe/ahxuxu.png)