### PR TITLE
Add reference to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ elementary OS desktop, with the adaptive light and dark panel based on the wallp
 | ----------------------------------------- | ---------------------------------------- |
 | ![Light](https://i.imgur.com/xpjjOxJ.png) | ![Dark](https://i.imgur.com/CzFvBj2.png) |
 
+You should avoid busy parts of the wallpaper in the top panel and bottom dock areas.
+
 ## To submit a wallpaper
 
 1. Make sure your wallpaper is openly-licensed and okay for commercial use

--- a/README.md
+++ b/README.md
@@ -15,6 +15,14 @@ Also keep in mind the desktop environment: elementary OS has a transparent panel
 * We prefer not to have photos with a single domesticated animal as a focus point
 * Wallpapers should be at least 3200×1800px
 
+### For Reference
+
+elementary OS desktop, with the adaptive light and dark panel based on the wallpaper:
+
+| Light Wallpaper                           | Dark Wallpaper                           |
+| ----------------------------------------- | ---------------------------------------- |
+| ![Light](https://i.imgur.com/xpjjOxJ.png) | ![Dark](https://i.imgur.com/CzFvBj2.png) |
+
 ## To submit a wallpaper
 
 1. Make sure your wallpaper is openly-licensed and okay for commercial use


### PR DESCRIPTION
Adds a simple light and dark reference screenshot to the README so people can see the areas to avoid in wallpapers, especially if they're not currently on elementary OS.
