### PR TITLE
John Towner - Red highlands

### DIFF
--- a/debian/copyright
+++ b/debian/copyright
@@ -1,6 +1,7 @@
 Unsplash photos are public domain:
 
 Ashim D'Silva <https://unsplash.com/photos/WeYamle9fDM>
+John Towner <https://unsplash.com/photos/JgOeRuGD_Y4>
 Jonas Nilsson Lee <https://unsplash.imgix.net/reserve/QGXfT1CkRpmvlwtPpgul_IMG_0558.jpg?q=75&fm=jpg&s=25c25f99c3faba09b92aacf40a9e9de5>
 leigh-kendell-581 <https://unsplash.com/@leighkendell>
 Mr. Lee <https://unsplash.com/photos/v7r8kZStqFw>
@@ -13,3 +14,4 @@ Carmine De Fazio <https://unsplash.com/photos/3ytjETpQMNY>
 Sunset by the Pier <https://unsplash.com/photos/ces8_Bo7bhQ>
 Luca Bravo <https://unsplash.com/photos/4yta6mU66dE>
 Morskie Oko <https://unsplash.com/photos/_1UF_3TlKcQ>
+


### PR DESCRIPTION
- [x] I've read and followed the [general guidelines](https://github.com/elementary/wallpapers#general-wallpaper-guidelines)
  - [x] Looks good in Pantheon on elementary OS
  - [x] Not too distracting if a non-maximized window is open
  - [x] No text or logos
  - [x] No people
  - [x] At least 3200×1800 px
- [x] I've updated `debian/copyright` with:
  - [x] The name of the wallpaper and/or its original author
  - [x] A link to where it can be downloaded
  - [x] Included under the respective license section (or created a new one if appropriate)
- [x] I've added the artist metadata using `exiftool`

## Why it should be included:

There is no other image with this color scheme. It has a bit of grain (which matches other elementary wallpapers), but also a lot of detail (which makes it look great on large screens).

## Screenshot(s) of it in Pantheon on elementary OS:

![Bildschirmfoto von 2019-07-13 13-22-07](https://user-images.githubusercontent.com/70772/61171255-4cd07f80-a575-11e9-9f8b-043f20268ba9.png)

I hope it works well in other aspect ratios as well.