### PR TITLE
Nattu Adnan

### DIFF
--- a/debian/copyright
+++ b/debian/copyright
@@ -4,6 +4,7 @@ Ashim D'Silva <https://unsplash.com/photos/WeYamle9fDM>
 Jonas Nilsson Lee <https://unsplash.imgix.net/reserve/QGXfT1CkRpmvlwtPpgul_IMG_0558.jpg?q=75&fm=jpg&s=25c25f99c3faba09b92aacf40a9e9de5>
 leigh-kendell-581 <https://unsplash.com/@leighkendell>
 Mr. Lee <https://unsplash.com/photos/v7r8kZStqFw>
+Naddu Adnan <https://unsplash.com/photos/Ai2TRdvI6gM>
 Pablo Garcia Saldaña <https://unsplash.com/photos/15d_4S2tJsQ>
 Rob Bye <https://unsplash.com/photos/Kc7xqFTtcc4>
 Ryan Schroeder <https://unsplash.com/photos/Gg7uKdHFb_c>


### PR DESCRIPTION
- [x] I've read and followed the [general guidelines](https://github.com/elementary/wallpapers#general-wallpaper-guidelines)
  - [x] Looks good in Pantheon on elementary OS
  - [x] Not too distracting if a non-maximized window is open
  - [x] No text or logos
  - [x] No people
  - [x] At least 3200×1800 px
- [x] I've updated `debian/copyright` with:
  - [x] The name of the wallpaper and/or its original author
  - [x] A link to where it can be downloaded
  - [x] Included under the respective license section (or created a new one if appropriate)
- [x] I've added the artist metadata using `exiftool`

## Why it should be included:

It's the first bright blue image, and it looks just reasonably good at 4k resolution.

There's already a wallpaper showing a beach, "Rob Bye.jpg", but it's a very different perspective and atmosphere. (It also has people in it and looks fuzzy on a large screen :/)

## Screenshot(s) of it in Pantheon on elementary OS:

![Bildschirmfoto von 2019-07-14 00-03-05](https://user-images.githubusercontent.com/70772/61177131-fba0aa00-a5cd-11e9-9be3-79f4e14b3126.png)
