### PR TITLE
Canazei Granite Ridges

### DIFF
--- a/debian/copyright
+++ b/debian/copyright
@@ -14,3 +14,5 @@ Carmine De Fazio <https://unsplash.com/photos/3ytjETpQMNY>
 Sunset by the Pier <https://unsplash.com/photos/ces8_Bo7bhQ>
 Luca Bravo <https://unsplash.com/photos/4yta6mU66dE>
 Morskie Oko <https://unsplash.com/photos/_1UF_3TlKcQ>
+Canazei Granite Ridges <https://unsplash.com/photos/yrwpJwDNSHE>
+


### PR DESCRIPTION
I had to ever-so-slightly edit the top to be a little less busy. We don't have a super good process in place to share those edits.

- [x] I've read and followed the [general guidelines](https://github.com/elementary/wallpapers#general-wallpaper-guidelines)
  - [x] Looks good in Pantheon on elementary OS
  - [x] Not too distracting if a non-maximized window is open
  - [x] No text or logos
  - [x] No people
  - [x] At least 3200×1800 px
- [x] I've updated `debian/copyright` with:
  - [x] The name of the wallpaper and/or its original author
  - [x] A link to where it can be downloaded
  - [x] Included under the respective license section (or created a new one if appropriate)
- [x] I've added the artist metadata using `exiftool`
## Why it should be included:

1. It's pretty :smile: 
2. It's an interesting lighter wallpaper which switches the panel to dark-on-transparent, which is a pretty unique look of elementary OS

## Screenshot(s) of it in Pantheon on elementary OS:

![Screenshot from 2019-09-19 17-04-35](https://user-images.githubusercontent.com/611168/65287718-6821b300-db01-11e9-96fc-2afa862cf687.png)
