### PR TITLE
appdata: Use newer, non-deprecated developer tag

### DIFF
--- a/data/wallpapers.appdata.xml.in
+++ b/data/wallpapers.appdata.xml.in
@@ -44,7 +44,9 @@
   </releases>
   <content_rating type="oars-1.1" />
   <translation type="gettext">io.elementary.wallpapers</translation>
-  <developer_name>elementary, Inc.</developer_name>
+  <developer id="org.elementaryos">
+    <name>elementary, Inc.</name>
+  </developer>
   <url type="homepage">https://elementary.io</url>
   <url type="bugtracker">https://github.com/elementary/wallpapers/issues</url>
 ​</component>


### PR DESCRIPTION
We need to do this in all repositories here, but just opening one first for feedback on the id.

The [docs](https://freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-developer) suggest RDNN for uniqueness. I used org here because I think we want to move away from io eventually? and this just needs to be consistent across all elementary appdata.